### PR TITLE
Migrate watchlist from localStorage to database

### DIFF
--- a/MarketAnalysisBackend/Controllers/WatchlistController.cs
+++ b/MarketAnalysisBackend/Controllers/WatchlistController.cs
@@ -86,5 +86,39 @@ namespace MarketAnalysisBackend.Controllers
             }
         }
 
+        /// <summary>
+        /// Get or create default watchlist for user
+        /// </summary>
+        [HttpGet("user/{userId}/default")]
+        public async Task<IActionResult> GetOrCreateDefaultWatchlist(int userId)
+        {
+            try
+            {
+                var watchlist = await _watchlistSer.GetOrCreateDefaultWatchlistAsync(userId);
+                return Ok(new { success = true, data = watchlist });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { success = false, error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// Toggle asset in default watchlist (add if not exists, remove if exists)
+        /// </summary>
+        [HttpPost("user/{userId}/toggle/{assetId}")]
+        public async Task<IActionResult> ToggleAssetInDefaultWatchlist(int userId, int assetId)
+        {
+            try
+            {
+                var result = await _watchlistSer.ToggleAssetInDefaultWatchlistAsync(userId, assetId);
+                return Ok(new { success = true, added = result.Added, watchlist = result.Watchlist });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { success = false, error = ex.Message });
+            }
+        }
+
         }
     }

--- a/MarketAnalysisBackend/Services/Interfaces/IWatchlistService.cs
+++ b/MarketAnalysisBackend/Services/Interfaces/IWatchlistService.cs
@@ -12,5 +12,13 @@ namespace MarketAnalysisBackend.Services.Interfaces
         Task AddAssetToWatchlistAsync(int watchlistId, int assetId);
         Task RemoveAssetFromWatchlistAsync(int watchlistId, int assetId);
         Task DeleteWatchlistAsync(int watchlistId);
+        Task<WatchlistDto> GetOrCreateDefaultWatchlistAsync(int userId);
+        Task<ToggleAssetResult> ToggleAssetInDefaultWatchlistAsync(int userId, int assetId);
+    }
+
+    public class ToggleAssetResult
+    {
+        public bool Added { get; set; }
+        public WatchlistDto Watchlist { get; set; } = null!;
     }
 }

--- a/MarketAnalysisFrontend/src/app/core/models/watchlist.model.ts
+++ b/MarketAnalysisFrontend/src/app/core/models/watchlist.model.ts
@@ -4,13 +4,38 @@
  */
 
 /**
- * Represents a user's watchlist containing cryptocurrency IDs
+ * Backend DTO for Asset
  */
-export interface Watchlist {
-  userId: string | null; // null for unauthenticated users
-  coinIds: string[];
-  createdAt: Date;
-  updatedAt: Date;
+export interface AssetDto {
+  id: number;
+  symbol: string;
+  name: string;
+}
+
+/**
+ * Backend DTO for Watchlist
+ */
+export interface WatchlistDto {
+  id: number;
+  name: string;
+  assets: AssetDto[];
+}
+
+/**
+ * Response from toggle endpoint
+ */
+export interface ToggleAssetResponse {
+  success: boolean;
+  added: boolean;
+  watchlist: WatchlistDto;
+}
+
+/**
+ * Response from get watchlist endpoint
+ */
+export interface WatchlistResponse {
+  success: boolean;
+  data: WatchlistDto;
 }
 
 /**
@@ -28,12 +53,4 @@ export interface WatchlistCoin {
   change24h?: string;
   isPositive24h: boolean;
   sparklineData?: number[];
-}
-
-/**
- * Local storage structure for watchlist persistence
- */
-export interface WatchlistStorage {
-  coinIds: string[];
-  timestamp: number;
 }

--- a/MarketAnalysisFrontend/src/app/features/dashboard/components/crypto-table/crypto-table.component.ts
+++ b/MarketAnalysisFrontend/src/app/features/dashboard/components/crypto-table/crypto-table.component.ts
@@ -51,7 +51,7 @@ export class CryptoTableComponent implements OnInit {
   selectedTab = 'Top';
   showNetworkMenu = signal(false);
   menuPosition: MenuPosition = { left: 0, top: 0 };
-  watchlistIds: string[] = [];
+  watchlistIds: number[] = [];
   isLoading: boolean = true;
 
   // Constants
@@ -216,13 +216,17 @@ export class CryptoTableComponent implements OnInit {
   // Watchlist Methods
   toggleWatchlist(coinId: string, event: MouseEvent): void {
     event.stopPropagation(); // Prevent row click navigation
-    
+
+    // Convert coinId to number (it's the asset ID from backend)
+    const assetId = Number(coinId);
+
     // WatchlistService will open auth modal if user is not authenticated
-    this.watchlistService.toggleWatchlist(coinId);
+    this.watchlistService.toggleWatchlist(assetId);
   }
 
   isInWatchlist(coinId: string): boolean {
-    return this.watchlistIds.includes(coinId);
+    const assetId = Number(coinId);
+    return this.watchlistIds.includes(assetId);
   }
 
   toggleNetworkMenu(): void {

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,403 @@
+# Watchlist Testing Guide
+
+## Prerequisites
+
+### 1. Start Backend
+```bash
+cd MarketAnalysisBackend
+dotnet run
+```
+Backend should be running on `https://localhost:7175`
+
+### 2. Start Frontend
+```bash
+cd MarketAnalysisFrontend
+npm start
+# or
+ng serve
+```
+Frontend should be running on `http://localhost:4200`
+
+### 3. Database
+Ensure PostgreSQL is running and database is migrated with latest schema.
+
+## Test Scenarios
+
+### Scenario 1: First Time User - Auto Create Watchlist
+
+**Steps:**
+1. Open browser → `http://localhost:4200`
+2. Click "Login" button
+3. Register a new account (e.g., `test1@example.com`)
+4. After login, open browser DevTools → Network tab
+5. Click star icon on any coin (e.g., Bitcoin)
+
+**Expected Results:**
+- ✅ Network tab shows POST request to `/api/Watchlist/user/{userId}/toggle/{assetId}`
+- ✅ Response: `{ success: true, added: true, watchlist: {...} }`
+- ✅ Star icon turns yellow (filled)
+- ✅ Coin appears in watchlist dropdown (header)
+
+**Database Check:**
+```sql
+-- Check if "My Watchlist" was created
+SELECT * FROM "Watchlist" WHERE "UserId" = 1;
+
+-- Check if asset was added
+SELECT * FROM "WatchlistItems" WHERE "WatchlistId" = 1;
+```
+
+---
+
+### Scenario 2: Toggle Watchlist (Add/Remove)
+
+**Steps:**
+1. Login as existing user
+2. Click star icon on Bitcoin → Should add
+3. Click star icon on Bitcoin again → Should remove
+4. Click star icon on Ethereum → Should add
+5. Check watchlist dropdown
+
+**Expected Results:**
+- ✅ First click: Star turns yellow, Bitcoin added
+- ✅ Second click: Star turns gray, Bitcoin removed
+- ✅ Third click: Star turns yellow, Ethereum added
+- ✅ Watchlist dropdown shows only Ethereum
+
+**Network Requests:**
+```
+POST /api/Watchlist/user/1/toggle/1  → { added: true }
+POST /api/Watchlist/user/1/toggle/1  → { added: false }
+POST /api/Watchlist/user/1/toggle/2  → { added: true }
+```
+
+---
+
+### Scenario 3: Watchlist Persistence
+
+**Steps:**
+1. Login as user
+2. Add 3 coins to watchlist (BTC, ETH, SOL)
+3. Refresh page (F5)
+4. Check watchlist dropdown
+
+**Expected Results:**
+- ✅ After refresh, watchlist still shows 3 coins
+- ✅ Star icons are still yellow for those 3 coins
+- ✅ Network tab shows GET request to `/api/Watchlist/user/{userId}/default`
+
+**Console Logs:**
+```
+✅ User info loaded on startup: { id: 1, email: "test1@example.com", ... }
+✅ Watchlist loaded from database
+```
+
+---
+
+### Scenario 4: Multi-User Isolation
+
+**Steps:**
+1. Login as User A (`test1@example.com`)
+2. Add Bitcoin and Ethereum to watchlist
+3. Logout
+4. Login as User B (`test2@example.com`)
+5. Check watchlist dropdown
+6. Add Solana to watchlist
+7. Logout
+8. Login back as User A
+9. Check watchlist dropdown
+
+**Expected Results:**
+- ✅ User A sees: Bitcoin, Ethereum
+- ✅ User B sees: Solana (empty at first)
+- ✅ After User A logs back in: Still sees Bitcoin, Ethereum
+- ✅ User B's Solana is NOT visible to User A
+
+**Database Check:**
+```sql
+-- User A's watchlist
+SELECT w.*, wi.*, a."Symbol" 
+FROM "Watchlist" w
+JOIN "WatchlistItems" wi ON w."Id" = wi."WatchlistId"
+JOIN "Asset" a ON wi."AssetId" = a."Id"
+WHERE w."UserId" = 1;
+
+-- User B's watchlist
+SELECT w.*, wi.*, a."Symbol" 
+FROM "Watchlist" w
+JOIN "WatchlistItems" wi ON w."Id" = wi."WatchlistId"
+JOIN "Asset" a ON wi."AssetId" = a."Id"
+WHERE w."UserId" = 2;
+```
+
+---
+
+### Scenario 5: Logout Clears Watchlist UI
+
+**Steps:**
+1. Login as user
+2. Add coins to watchlist
+3. Verify watchlist dropdown shows coins
+4. Logout
+5. Check watchlist dropdown
+
+**Expected Results:**
+- ✅ After logout, watchlist dropdown is empty
+- ✅ Star icons are all gray (not filled)
+- ✅ Console shows: `Watchlist cleared on logout`
+
+---
+
+### Scenario 6: Unauthenticated User
+
+**Steps:**
+1. Logout (or open incognito window)
+2. Go to dashboard
+3. Click star icon on any coin
+
+**Expected Results:**
+- ✅ Auth modal opens (login/signup)
+- ✅ No API request is made
+- ✅ Star icon remains gray
+
+---
+
+### Scenario 7: Real-time Price Updates in Watchlist
+
+**Steps:**
+1. Login as user
+2. Add Bitcoin to watchlist
+3. Open watchlist dropdown
+4. Wait for price updates (SignalR)
+
+**Expected Results:**
+- ✅ Watchlist dropdown shows Bitcoin with current price
+- ✅ Price updates in real-time (every few seconds)
+- ✅ 24h change updates
+- ✅ Sparkline chart updates
+
+---
+
+### Scenario 8: Navigate to Coin from Watchlist
+
+**Steps:**
+1. Login as user
+2. Add Bitcoin to watchlist
+3. Open watchlist dropdown
+4. Click on Bitcoin in the dropdown
+
+**Expected Results:**
+- ✅ Navigates to `/coin/btc` page
+- ✅ Watchlist dropdown closes
+- ✅ Coin detail page loads
+
+---
+
+## API Testing (Postman/cURL)
+
+### 1. Get or Create Default Watchlist
+```bash
+curl -X GET "https://localhost:7175/api/Watchlist/user/1/default" \
+  -H "accept: application/json"
+```
+
+**Expected Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "name": "My Watchlist",
+    "assets": []
+  }
+}
+```
+
+### 2. Toggle Asset (Add)
+```bash
+curl -X POST "https://localhost:7175/api/Watchlist/user/1/toggle/1" \
+  -H "accept: application/json"
+```
+
+**Expected Response:**
+```json
+{
+  "success": true,
+  "added": true,
+  "watchlist": {
+    "id": 1,
+    "name": "My Watchlist",
+    "assets": [
+      {
+        "id": 1,
+        "symbol": "BTC",
+        "name": "Bitcoin"
+      }
+    ]
+  }
+}
+```
+
+### 3. Toggle Asset (Remove)
+```bash
+curl -X POST "https://localhost:7175/api/Watchlist/user/1/toggle/1" \
+  -H "accept: application/json"
+```
+
+**Expected Response:**
+```json
+{
+  "success": true,
+  "added": false,
+  "watchlist": {
+    "id": 1,
+    "name": "My Watchlist",
+    "assets": []
+  }
+}
+```
+
+---
+
+## Common Issues & Debugging
+
+### Issue 1: "Cannot toggle watchlist: User ID not available"
+
+**Cause:** `currentUserSubject` is null
+
+**Fix:**
+- Check if `getUserInfo()` is called after login
+- Check browser console for user info logs
+- Verify token is stored in localStorage
+
+**Debug:**
+```javascript
+// In browser console
+localStorage.getItem('token')
+// Should return JWT token
+```
+
+### Issue 2: Star icon doesn't change color
+
+**Cause:** Type mismatch between `coin.id` and `watchlistIds`
+
+**Fix:**
+- Ensure `coin.id` is converted to number
+- Check `isInWatchlist()` method
+
+**Debug:**
+```typescript
+// In crypto-table.component.ts
+console.log('Coin ID type:', typeof coin.id);
+console.log('Watchlist IDs:', this.watchlistIds);
+```
+
+### Issue 3: Watchlist not loading on page refresh
+
+**Cause:** `getUserInfo()` not called on app startup
+
+**Fix:**
+- Check `checkAuthStatus()` in AuthService
+- Ensure it calls `getUserInfo()` when token exists
+
+**Debug:**
+```javascript
+// In browser console
+// Check if user info is loaded
+console.log(authService.currentUserSubject.value);
+```
+
+### Issue 4: CORS error
+
+**Cause:** Backend CORS not configured for frontend URL
+
+**Fix:**
+- Check `Program.cs` CORS configuration
+- Ensure `http://localhost:4200` is allowed
+
+### Issue 5: 404 on API endpoints
+
+**Cause:** Backend not running or wrong URL
+
+**Fix:**
+- Verify backend is running on `https://localhost:7175`
+- Check `watchlist.service.ts` apiUrl constant
+
+---
+
+## Performance Testing
+
+### Load Test: Multiple Users
+1. Create 10 users
+2. Each user adds 20 coins to watchlist
+3. Check database query performance
+4. Monitor API response times
+
+**Expected:**
+- ✅ API response < 200ms
+- ✅ No N+1 query issues
+- ✅ Database indexes working
+
+### Stress Test: Rapid Toggles
+1. Login as user
+2. Rapidly click star icon 10 times
+3. Check if all requests complete
+4. Verify final state is correct
+
+**Expected:**
+- ✅ All requests complete successfully
+- ✅ Final state matches last request
+- ✅ No race conditions
+
+---
+
+## Checklist
+
+### Backend
+- [ ] Build succeeds without errors
+- [ ] Database migrations applied
+- [ ] Backend running on https://localhost:7175
+- [ ] Swagger UI accessible at /swagger
+
+### Frontend
+- [ ] Build succeeds without errors
+- [ ] Frontend running on http://localhost:4200
+- [ ] No console errors on page load
+
+### Functionality
+- [ ] User can login/logout
+- [ ] Star icon toggles watchlist
+- [ ] Watchlist persists after refresh
+- [ ] Multi-user isolation works
+- [ ] Watchlist dropdown shows correct coins
+- [ ] Real-time price updates work
+- [ ] Navigate to coin from watchlist works
+
+### Database
+- [ ] Watchlist table has data
+- [ ] WatchlistItems table has data
+- [ ] Data is correctly associated with users
+- [ ] No orphaned records
+
+---
+
+## Success Criteria
+
+✅ **All test scenarios pass**
+✅ **No console errors**
+✅ **No network errors**
+✅ **Database data is correct**
+✅ **Multi-user isolation confirmed**
+✅ **Performance is acceptable**
+
+---
+
+## Next Steps After Testing
+
+1. **Fix any bugs found during testing**
+2. **Add error handling for edge cases**
+3. **Add loading states for API calls**
+4. **Add success/error notifications**
+5. **Consider adding unit tests**
+6. **Consider adding E2E tests with Cypress/Playwright**
+

--- a/WATCHLIST_MIGRATION_SUMMARY.md
+++ b/WATCHLIST_MIGRATION_SUMMARY.md
@@ -1,0 +1,223 @@
+# Watchlist Migration: LocalStorage → Database
+
+## Tóm tắt thay đổi
+
+Đã chuyển đổi watchlist từ localStorage sang database với phân chia theo từng user.
+
+## Backend Changes
+
+### 1. WatchlistController.cs
+**Thêm 2 endpoints mới:**
+
+- `GET /api/Watchlist/user/{userId}/default`
+  - Lấy hoặc tạo watchlist mặc định cho user
+  - Tự động tạo watchlist "My Watchlist" nếu chưa có
+
+- `POST /api/Watchlist/user/{userId}/toggle/{assetId}`
+  - Toggle asset trong watchlist (thêm nếu chưa có, xóa nếu đã có)
+  - Trả về trạng thái `added: true/false` và watchlist đã cập nhật
+
+### 2. IWatchlistService.cs
+**Thêm interface methods:**
+```csharp
+Task<WatchlistDto> GetOrCreateDefaultWatchlistAsync(int userId);
+Task<ToggleAssetResult> ToggleAssetInDefaultWatchlistAsync(int userId, int assetId);
+```
+
+**Thêm class:**
+```csharp
+public class ToggleAssetResult
+{
+    public bool Added { get; set; }
+    public WatchlistDto Watchlist { get; set; }
+}
+```
+
+### 3. WatchlistService.cs
+**Implement 2 methods mới:**
+- `GetOrCreateDefaultWatchlistAsync()`: Tạo watchlist "My Watchlist" nếu chưa có
+- `ToggleAssetInDefaultWatchlistAsync()`: Toggle asset và trả về kết quả
+
+## Frontend Changes
+
+### 1. watchlist.model.ts
+**Cập nhật models để match với backend DTOs:**
+```typescript
+export interface AssetDto {
+  id: number;
+  symbol: string;
+  name: string;
+}
+
+export interface WatchlistDto {
+  id: number;
+  name: string;
+  assets: AssetDto[];
+}
+
+export interface ToggleAssetResponse {
+  success: boolean;
+  added: boolean;
+  watchlist: WatchlistDto;
+}
+```
+
+### 2. watchlist.service.ts
+**Thay đổi lớn:**
+- ❌ Xóa: localStorage operations
+- ✅ Thêm: HTTP calls đến backend API
+- ✅ Thêm: `loadWatchlistFromDatabase()` - Load từ database khi user login
+- ✅ Thay đổi: `toggleWatchlist()` - Gọi API thay vì update localStorage
+- ✅ Thay đổi: `watchlistIds` từ `string[]` → `number[]` (asset IDs)
+
+**Key changes:**
+```typescript
+// Old: localStorage
+private loadWatchlistFromLocalStorage(): void { ... }
+private saveWatchlistToLocalStorage(coinIds: string[]): void { ... }
+
+// New: API calls
+private loadWatchlistFromDatabase(): void {
+  this.http.get<WatchlistResponse>(`${apiUrl}/user/${userId}/default`)
+    .subscribe(...)
+}
+
+toggleWatchlist(coinId: number): boolean {
+  this.http.post<ToggleAssetResponse>(`${apiUrl}/user/${userId}/toggle/${coinId}`, {})
+    .subscribe(...)
+}
+```
+
+### 3. auth.service.ts
+**Cập nhật để load user info:**
+- `setUser()`: Gọi `getUserInfo()` sau khi set token
+- `checkAuthStatus()`: Load user info khi app khởi động
+- `logout()`: Clear `currentUserSubject`
+
+**Lý do:** WatchlistService cần `userId` từ `currentUserSubject` để gọi API
+
+### 4. crypto-table.component.ts
+**Cập nhật type:**
+```typescript
+// Old
+watchlistIds: string[] = [];
+toggleWatchlist(coinId: string, event: MouseEvent)
+isInWatchlist(coinId: string): boolean
+
+// New
+watchlistIds: number[] = [];
+toggleWatchlist(coinId: string, event: MouseEvent) {
+  const assetId = Number(coinId);
+  this.watchlistService.toggleWatchlist(assetId);
+}
+isInWatchlist(coinId: string): boolean {
+  const assetId = Number(coinId);
+  return this.watchlistIds.includes(assetId);
+}
+```
+
+## Database Schema (Đã có sẵn)
+
+```
+Watchlist
+├── Id (int, PK)
+├── UserId (int, FK → User)
+├── Name (string)
+└── IsFavorite (bool)
+
+WatchlistItems
+├── Id (int, PK)
+├── WatchlistId (int, FK → Watchlist)
+├── AssetId (int, FK → Asset)
+└── AddedAt (DateTime)
+```
+
+## Flow hoạt động
+
+### 1. User Login
+```
+1. User login → AuthService.setUser()
+2. AuthService.getUserInfo() → Load UserInfo vào currentUserSubject
+3. WatchlistService effect() detect isAuthenticated = true
+4. WatchlistService.loadWatchlistFromDatabase()
+5. GET /api/Watchlist/user/{userId}/default
+6. Backend tự động tạo "My Watchlist" nếu chưa có
+7. Frontend nhận danh sách asset IDs và update watchlistIdsSubject
+```
+
+### 2. Toggle Watchlist
+```
+1. User click star icon → toggleWatchlist(assetId)
+2. POST /api/Watchlist/user/{userId}/toggle/{assetId}
+3. Backend check asset có trong watchlist không
+   - Có: Remove asset
+   - Không: Add asset
+4. Backend trả về { added: bool, watchlist: WatchlistDto }
+5. Frontend update watchlistIdsSubject với danh sách mới
+6. UI tự động update (reactive)
+```
+
+### 3. User Logout
+```
+1. User logout → AuthService.logout()
+2. Clear currentUserSubject
+3. WatchlistService effect() detect isAuthenticated = false
+4. Clear watchlistIdsSubject và watchlistCoinsSubject
+```
+
+## Testing Checklist
+
+### Backend Testing
+- [ ] GET /api/Watchlist/user/{userId}/default - Tạo watchlist mặc định
+- [ ] POST /api/Watchlist/user/{userId}/toggle/{assetId} - Add asset
+- [ ] POST /api/Watchlist/user/{userId}/toggle/{assetId} - Remove asset (toggle lần 2)
+- [ ] Kiểm tra database: Watchlist và WatchlistItems được tạo đúng
+- [ ] Test với nhiều user khác nhau - watchlist phân chia đúng
+
+### Frontend Testing
+- [ ] Login → Watchlist tự động load từ database
+- [ ] Click star icon → Asset được add vào watchlist
+- [ ] Click star icon lần 2 → Asset được remove
+- [ ] Logout → Watchlist bị clear
+- [ ] Login với user khác → Load watchlist của user đó
+- [ ] Watchlist dropdown hiển thị đúng coins
+- [ ] Real-time price updates trong watchlist dropdown
+
+### Integration Testing
+- [ ] User A add BTC → Chỉ user A thấy
+- [ ] User B add ETH → Chỉ user B thấy
+- [ ] User A logout/login lại → Vẫn thấy BTC
+- [ ] Refresh page → Watchlist vẫn còn (load từ DB)
+
+## Migration Notes
+
+### Dữ liệu cũ trong localStorage
+- Dữ liệu cũ trong localStorage sẽ KHÔNG được migrate tự động
+- User cần add lại coins vào watchlist
+- Có thể viết script migration nếu cần (đọc localStorage → POST vào API)
+
+### Breaking Changes
+- `watchlistIds` type changed: `string[]` → `number[]`
+- `toggleWatchlist()` parameter: `string` → `number`
+- `isInWatchlist()` parameter: `string` → `number`
+
+## API Endpoints Summary
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/Watchlist/user/{userId}` | Get all watchlists của user |
+| GET | `/api/Watchlist/user/{userId}/default` | Get/create default watchlist |
+| GET | `/api/Watchlist/{watchlistId}` | Get watchlist by ID |
+| POST | `/api/Watchlist/{userId}/create?name={name}` | Create new watchlist |
+| POST | `/api/Watchlist/user/{userId}/toggle/{assetId}` | Toggle asset in default watchlist |
+| POST | `/api/Watchlist/{watchlistId}/add/{assetId}` | Add asset to watchlist |
+| DELETE | `/api/Watchlist/{watchlistId}/remove/{assetId}` | Remove asset from watchlist |
+
+## Next Steps (Optional)
+
+1. **Multiple Watchlists**: Cho phép user tạo nhiều watchlist
+2. **Watchlist Sharing**: Chia sẻ watchlist với users khác
+3. **Import/Export**: Export watchlist ra CSV/JSON
+4. **Migration Script**: Migrate localStorage data sang database
+5. **Offline Support**: Cache watchlist trong IndexedDB cho offline access
+


### PR DESCRIPTION
Watchlist functionality now uses backend API and database per user instead of localStorage. Added endpoints to get/create default watchlist and toggle assets. Updated frontend models, services, and components to use asset IDs and backend DTOs. AuthService now loads user info for watchlist API calls. Includes testing and migration documentation.